### PR TITLE
Context accessor method

### DIFF
--- a/core/src/main/scala/tofu/Context.scala
+++ b/core/src/main/scala/tofu/Context.scala
@@ -114,6 +114,7 @@ object Context {
     * }}}
     */
   trait Companion[C] extends ContextInstances[C] {
+
     type Has[F[_]] = WithContext[F, C]
 
     implicit def promoteContextStructure[F[_], A](implicit
@@ -121,6 +122,11 @@ object Context {
         field: C Contains A
     ): WithContextContainsInstance[F, C, A] =
       new WithContextContainsInstance[F, C, A]
+
+    /** Access [[C]] in [[F]].
+      */
+    final def access[F[_]](implicit has: Has[F]): F[C] =
+      has.context
   }
 
   trait ContextInstances[C] {


### PR DESCRIPTION
Helper method allowing to access dependencies in context in slightly more convenient way when there are multiple of them:
```scala
import tofu.syntax.context._
def foo[F[_]: Monad: Foo.Has: Bar.Has]: F[X] =
  (hasContext[F, Foo], hasContext[F, Bar]).mapN((f, b) => ???)
```
vs
```scala
def foo[F[_]: Monad: Foo.Has: Bar.Has]: F[X] =
  (Foo.access, Bar.access).mapN((f, b) => ???)
```