### PR TITLE
Drop sbt-0.13.x syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -285,12 +285,12 @@ lazy val docs = project // new documentation project
     defaultSettings,
     addCompilerPlugin(simulacrum),
     macros,
-    scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-expand:none",
-    unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(allModuleRefs: _*) -- inProjects(opticsMacro),
-    target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",
-    cleanFiles += (target in (ScalaUnidoc, unidoc)).value,
-    docusaurusCreateSite := docusaurusCreateSite.dependsOn(unidoc in Compile).value,
-    docusaurusPublishGhpages := docusaurusPublishGhpages.dependsOn(unidoc in Compile).value
+    ScalaUnidoc / unidoc / scalacOptions += "-Ymacro-expand:none",
+    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(allModuleRefs: _*) -- inProjects(opticsMacro),
+    ScalaUnidoc / unidoc / target := (LocalRootProject / baseDirectory).value / "website" / "static" / "api",
+    cleanFiles += (ScalaUnidoc / unidoc / target).value,
+    docusaurusCreateSite := docusaurusCreateSite.dependsOn(Compile / unidoc).value,
+    docusaurusPublishGhpages := docusaurusPublishGhpages.dependsOn(Compile / unidoc).value
   )
   .dependsOn(allModuleDeps: _*)
   .enablePlugins(MdocPlugin, DocusaurusPlugin, ScalaUnidocPlugin)
@@ -378,7 +378,7 @@ lazy val publishSettings = Seq(
     if (branch == "master") publishVersion.value
     else s"${publishVersion.value}-$branch-SNAPSHOT"
   },
-  sources in (Compile, doc) := Seq.empty,
+  Compile / doc / sources := Seq.empty,
   scmInfo := Some(
     ScmInfo(
       url("https://github.com/TinkoffCreditSystems/tofu"),


### PR DESCRIPTION
This is to fix warnings in sbt:
```
[info] loading project definition from /home/runner/work/tofu/tofu/project
/home/runner/work/tofu/tofu/build.sbt:288: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-expand:none",
                  ^
/home/runner/work/tofu/tofu/build.sbt:289: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(allModuleRefs: _*) -- inProjects(opticsMacro),
                        ^
/home/runner/work/tofu/tofu/build.sbt:290: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",
           ^
/home/runner/work/tofu/tofu/build.sbt:290: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",
                                                      ^
/home/runner/work/tofu/tofu/build.sbt:291: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    cleanFiles += (target in (ScalaUnidoc, unidoc)).value,
                          ^
/home/runner/work/tofu/tofu/build.sbt:292: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    docusaurusCreateSite := docusaurusCreateSite.dependsOn(unidoc in Compile).value,
                                                                  ^
/home/runner/work/tofu/tofu/build.sbt:293: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    docusaurusPublishGhpages := docusaurusPublishGhpages.dependsOn(unidoc in Compile).value
                                                                          ^
/home/runner/work/tofu/tofu/build.sbt:381: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
  sources in (Compile, doc) := Seq.empty,
```