### PR TITLE
CalcM methods for StateT

### DIFF
--- a/data/src/main/scala/tofu/data/calc/CalcM.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcM.scala
@@ -26,9 +26,9 @@ object CalcM extends CalcMInstances {
   def get[S]: CalcM[Nothing, Any, S, S, Nothing, S]           = Get()
   def set[S](s: S): CalcM[Nothing, Any, Any, S, Nothing, S]   = Set(s)
 
-  def update[S1, S2](f: S1 => S2): CalcM[Nothing, Any, S1, S2, Nothing, S2]                                  =
+  def update[S1, S2](f: S1 => S2): CalcM[Nothing, Any, S1, S2, Nothing, S2]       =
     get[S1].flatMapS(s => set(f(s)))
-  def state[S1, S2, A](f: S1 => (S2, A)): CalcM[Nothing, Any, S1, S2, Nothing, A]                            =
+  def state[S1, S2, A](f: S1 => (S2, A)): CalcM[Nothing, Any, S1, S2, Nothing, A] =
     get[S1].flatMapS { s1 =>
       val (s2, a) = f(s1)
       set(s2) as a

--- a/data/src/main/scala/tofu/data/calc/CalcM.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcM.scala
@@ -7,7 +7,6 @@ import cats.Monoid
 
 import scala.annotation.tailrec
 import cats.evidence.As
-import tofu.data.CalcT
 
 sealed abstract class CalcM[+F[+_, +_], -R, -SI, +SO, +E, +A] extends CalcMOps[F, R, SI, SO, E, A] {
   def translateState[G[+_, +_], ST, R1](
@@ -34,12 +33,14 @@ object CalcM extends CalcMInstances {
       val (s2, a) = f(s1)
       set(s2) as a
     }
-  def stateT[F[+_], S1, S2, A](f: S1 => F[(S2, A)]): CalcM[λ[(`+x`, `+y`) => F[y]], Any, S1, S2, Nothing, A] =
+  def stateT[F[+_], S1, S2, A](f: S1 => F[(S2, A)]): CalcM[λ[(`+x`, `+y`) => F[y]], Any, S1, S2, Nothing, A] = {
+    type F2[+x, +y] = F[y]
     CalcM.get[S1].flatMapS { s1 =>
-      CalcT.lift(f(s1)).flatMapS { case (s2, x) =>
+      CalcT.lift(f(s1)).flatMapS[F2, Any, S2, Nothing, A] { case (s2, x) =>
         CalcM.set(s2) as x
       }
     }
+  }
 
   def raise[S, E](e: E): CalcM[Nothing, Any, S, S, E, Nothing]           = Raise(e)
   def defer[F[+_, +_], R, S1, S2, E, A](x: => CalcM[F, R, S1, S2, E, A]) = Defer(() => x)

--- a/data/src/main/scala/tofu/data/calc/CalcMOps.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcMOps.scala
@@ -167,7 +167,7 @@ class CalcMOps[+F[+_, +_], -R, -SI, +SO, +E, +A] { self: CalcM[F, R, SI, SO, E, 
   ): F1[(SO, A)] = {
     type F2[+x, +y] = F1[y]
     F.tailRecM[CalcM[F2, Any, Any, SO, Nothing, A], (SO, A)](
-      ev.substituteCo[CalcM[F2, Any, Any, SO, +*, A]](this.provideSet(r, init).widenF[F2])
+      this.provideSet(r, init).mapError(ev.apply).widenF[F2]
     ) { s =>
       s.step((), ()) match {
         case StepResult.Ok(s, a)                                   => F.pure(Right((s, a)))

--- a/data/src/main/scala/tofu/data/calc/CalcMOps.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcMOps.scala
@@ -163,11 +163,11 @@ class CalcMOps[+F[+_, +_], -R, -SI, +SO, +E, +A] { self: CalcM[F, R, SI, SO, E, 
 
   def runTailRecSingle[F1[+y] >: F[Any, y] @uv212, E1 >: E @uv212](r: R, init: SI)(implicit
       F: Monad[F1],
-      ev: E1 =:= Nothing
+      ev: E1 <:< Nothing
   ): F1[(SO, A)] = {
     type F2[+x, +y] = F1[y]
     F.tailRecM[CalcM[F2, Any, Any, SO, Nothing, A], (SO, A)](
-      ev.substituteCo[CalcM[F2, Any, Any, SO, *, A]](this.provideSet(r, init).widenF[F2])
+      ev.substituteCo[CalcM[F2, Any, Any, SO, +*, A]](this.provideSet(r, init).widenF[F2])
     ) { s =>
       s.step((), ()) match {
         case StepResult.Ok(s, a)                                   => F.pure(Right((s, a)))

--- a/data/src/main/scala/tofu/data/calc/CalcMOps.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcMOps.scala
@@ -161,7 +161,7 @@ class CalcMOps[+F[+_, +_], -R, -SI, +SO, +E, +A] { self: CalcM[F, R, SI, SO, E, 
     }
   }
 
-  def runTailRecSingle[F1[+y] >: F[Any, y] @uv212, E1 >: E @uv212](r: R, init: SI)(implicit
+  def runTailRecSingle[F1[+y] >: F[Any, y] @uv212, E1 >: E](r: R, init: SI)(implicit
       F: Monad[F1],
       ev: E1 <:< Nothing
   ): F1[(SO, A)] = {


### PR DESCRIPTION
When you need covariant StateT, you can do
```scala
type StateT[+F[+_], S, +x] = CalcT[F, Any, S, S, Nothing, x]
```
This pull request adds helpers `stateT` and `runTailRecSingle`:
```scala
def pop: StateT[IO, Vector[Int], Option[Int]] =
    CalcM.stateT(v =>
      IO(println("popping")).as((v.tail, v.headOption))
    )

  def code: StateT[IO, Vector[Int], Unit] = {
    for {
      x <- pop
      _ <- CalcT.lift(IO(println(x)))
      y <- pop
      _ <- CalcT.lift(IO(println(y)))
    } yield ()
  }

  val run: IO[(Vector[Int], Unit)] = code.runTailRecSingle((), Vector(1, 2, 4, 5))
```

