### PR TITLE
Fix Tinkoff link

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -18,7 +18,7 @@ const users = [
     // You will need to prepend the image path with your baseUrl
     // if it is not '/', like: '/test-site/img/image.jpg'.
     image: '/img/tinkoff-bank-general-logo-1.png',
-    infoLink: 'tinkoff.ru',
+    infoLink: 'https://www.tinkoff.ru',
     pinned: true,
   },
 ];


### PR DESCRIPTION
The link in the user showcases currently links to https://docs.tofu.tf/en/tinkoff.ru because it is only relative.