### PR TITLE
Guarantee kernelize

### DIFF
--- a/concurrent/src/main/scala/tofu/concurrent/Daemon.scala
+++ b/concurrent/src/main/scala/tofu/concurrent/Daemon.scala
@@ -2,7 +2,7 @@ package tofu
 package concurrent
 
 import cats.data.StateT
-import cats.effect._
+import cats.effect.{MonadThrow => _, _}
 import cats.effect.concurrent.{MVar, TryableDeferred}
 import cats.effect.syntax.bracket._
 import cats.syntax.applicativeError._

--- a/core/src/main/scala/tofu/package.scala
+++ b/core/src/main/scala/tofu/package.scala
@@ -1,29 +1,10 @@
 import cats.effect.Bracket
-import cats.{ApplicativeError, MonadError}
 import cats.data.Ior
+import tofu.kernel.KernelTypes
 
-package object tofu {
-  type In[C, F[_]] = WithContext[F, C]
+package object tofu extends KernelTypes {
 
-  type HasContext[F[_], C] = Context[F] { type Ctx = C }
-
-  type HasLocal[F[_], C] = Local[F] { type Ctx = C }
-
-  type HasProvide[F[_], G[_], C] = WithProvide[F, G, C]
-
-  type HasContextRun[F[_], G[_], C] = WithRun[F, G, C]
-
-  type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
-  type MonadThrow[F[_]]       = MonadError[F, Throwable]
-  type BracketThrow[F[_]]     = Bracket[F, Throwable]
-
-  type Throws[F[_]]  = Raise[F, Throwable]
-  type Catches[F[_]] = Handle[F, Throwable]
-  type Tries[F[_]]   = Errors[F, Throwable]
-
-  type TConst[A, B] = A
-
-  private[tofu] type AnyK[_] = Any
+  type BracketThrow[F[_]] = Bracket[F, Throwable]
 
   type IorC[C[_], E, A] = Ior[C[E], C[A]]
 

--- a/core/src/test/scala/tofu/GuaranteeSuite.scala
+++ b/core/src/test/scala/tofu/GuaranteeSuite.scala
@@ -6,7 +6,7 @@ object GuaranteeSuite {
 
   def summonInstancesForBracket[F[_]: BracketThrow](): Unit = {
     implicitly[Guarantee[F]]
-    implicitly[Finally[F, TConst[ExitCase[Throwable], *]]]
+    implicitly[Finally[F, TConst[ExitCase[Throwable], *]]](Finally.fromBracket)
     ()
   }
 

--- a/core/src/test/scala/tofu/GuaranteeSuite.scala
+++ b/core/src/test/scala/tofu/GuaranteeSuite.scala
@@ -1,12 +1,27 @@
 package tofu
 
-import cats.effect.ExitCase
+import scala.annotation.nowarn
+import tofu.interop.CE2Kernel.CEExit
 
 object GuaranteeSuite {
 
+  def summonFinally[F[_]] = new SummonSomeFinally[F]
+
+  class SummonSomeFinally[F[_]] {
+    def some[Exit[_]](implicit fin: Finally[F, Exit]): Finally[F, Exit]                               = fin
+    def carrier(implicit cc: FinallyCarrier[F, Throwable]): FinallyCarrier.Aux[F, Throwable, cc.Exit] = cc
+  }
+
   def summonInstancesForBracket[F[_]: BracketThrow](): Unit = {
     implicitly[Guarantee[F]]
-    implicitly[Finally[F, TConst[ExitCase[Throwable], *]]](Finally.fromBracket)
+
+    implicitly[FinallyCarrier.Aux[F, Throwable, CEExit[Throwable, *]]]
+
+    implicitly[Finally[F, CEExit[Throwable, *]]]
+
+    val xx                                           = summonFinally[F].some
+    @nowarn val yy: Finally[F, CEExit[Throwable, *]] = xx
+
     ()
   }
 

--- a/kernel/src/main/scala/tofu/Guarantee.scala
+++ b/kernel/src/main/scala/tofu/Guarantee.scala
@@ -24,7 +24,7 @@ trait GuaranteeInstanceChain[T[f[_]] >: Guarantee[f]] extends FinallyInstanceCha
   * @tparam F effect process
   * @tparam Exit structure, describing process exit like `ExitCase` or `Exit`
   */
-trait Finally[F[_], Exit[_]] extends Guarantee[F] {
+trait Finally[F[_], +Exit[_]] extends Guarantee[F] {
 
   /** guarantee of finalization
     * @param init initialization process, probably acquiring some resources, need for finalization

--- a/kernel/src/main/scala/tofu/internal/Interop.scala
+++ b/kernel/src/main/scala/tofu/internal/Interop.scala
@@ -1,23 +1,30 @@
 package tofu.internal
-import scala.reflect.macros.blackbox._
-import scala.annotation.unused
+import scala.reflect.macros._
 
-class Interop(val c: Context) {
+class Interop(val c: blackbox.Context) {
   import c.universe._
   import c.{WeakTypeTag => WTT}
-  private type WTTU[F[_]] = WTT[F[Unit]]
+  type WTTU[F[_]] = WTT[F[Unit]]
 
-  private def tc[F[_]](implicit wttu: WTTU[F]) = wttu.tpe.typeConstructor
-  private def t[A](implicit wttu: WTT[A])      = wttu.tpe
+  protected def tc[F[_]](implicit wttu: WTTU[F]) = wttu.tpe.typeConstructor
+  protected def t[A](implicit wttu: WTT[A])      = wttu.tpe
 
-  private def delegateImpl[R, N](ts: Type*)(implicit R: WTT[R], N: WTT[N]): c.Expr[R] = {
+  protected def delegateTree[N](ts: Type*)(implicit N: WTT[N]): Tree = {
     val s   = N.tpe.decls.head.asTerm.name.decodedName.toString
     val exp = c.parse(s)
 
-    c.Expr[R](q"$exp[..$ts]")
+    q"$exp[..$ts]"
   }
+
+  private def delegateImpl[R: WTT, N: WTT](ts: Type*): c.Expr[R] =
+    c.Expr[R](delegateTree[N](ts: _*))
 
   def delegate[R: WTT, F[_]: WTTU, N: WTT]: c.Expr[R] = delegateImpl[R, N](tc[F])
 
-  def delegate1e1[R: WTT, F[_]: WTTU, A: WTT, N: WTT](@unused ev1: Tree): c.Expr[R] = delegateImpl[R, N](tc[F], t[A])
+}
+
+class WBInterop(override val c: whitebox.Context) extends Interop(c) {
+  import c.universe._
+  import c.{WeakTypeTag => WTT}
+  def delegate1[F[_]: WTTU, A: WTT, N: WTT]: Tree = delegateTree[N](tc[F], t[A])
 }

--- a/kernel/src/main/scala/tofu/internal/Interop.scala
+++ b/kernel/src/main/scala/tofu/internal/Interop.scala
@@ -1,5 +1,6 @@
 package tofu.internal
 import scala.reflect.macros.blackbox._
+import scala.annotation.unused
 
 class Interop(val c: Context) {
   import c.universe._
@@ -7,6 +8,7 @@ class Interop(val c: Context) {
   private type WTTU[F[_]] = WTT[F[Unit]]
 
   private def tc[F[_]](implicit wttu: WTTU[F]) = wttu.tpe.typeConstructor
+  private def t[A](implicit wttu: WTT[A])      = wttu.tpe
 
   private def delegateImpl[R, N](ts: Type*)(implicit R: WTT[R], N: WTT[N]): c.Expr[R] = {
     val s   = N.tpe.decls.head.asTerm.name.decodedName.toString
@@ -16,4 +18,6 @@ class Interop(val c: Context) {
   }
 
   def delegate[R: WTT, F[_]: WTTU, N: WTT]: c.Expr[R] = delegateImpl[R, N](tc[F])
+
+  def delegate1e1[R: WTT, F[_]: WTTU, A: WTT, N: WTT](@unused ev1: Tree): c.Expr[R] = delegateImpl[R, N](tc[F], t[A])
 }

--- a/kernel/src/main/scala/tofu/kernel/types.scala
+++ b/kernel/src/main/scala/tofu/kernel/types.scala
@@ -1,10 +1,12 @@
-package tofu.kernel
+package tofu
+package kernel
 
-import tofu.{WithContext, Local, Context}
-import tofu.WithProvide
-import tofu.WithRun
+import cats.ApplicativeError
+import cats.MonadError
 
-object types {
+object types extends KernelTypes
+
+trait KernelTypes extends Any {
   type In[C, F[_]] = WithContext[F, C]
 
   type HasContext[F[_], C] = Context[F] { type Ctx = C }
@@ -16,4 +18,13 @@ object types {
   type HasContextRun[F[_], G[_], C] = WithRun[F, G, C]
 
   type AnyK[_] = Any
+
+  type TConst[A, B] = A
+
+  type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
+  type MonadThrow[F[_]]       = MonadError[F, Throwable]
+
+  type Throws[F[_]]  = Raise[F, Throwable]
+  type Catches[F[_]] = Handle[F, Throwable]
+  type Tries[F[_]]   = Errors[F, Throwable]
 }

--- a/kernelCE2Interop/src/main/scala/tofu/interop/CE2Kernel.scala
+++ b/kernelCE2Interop/src/main/scala/tofu/interop/CE2Kernel.scala
@@ -14,6 +14,10 @@ import scala.concurrent.duration.FiniteDuration
 import tofu.Timeout
 import tofu.internal.NonTofu
 import tofu.compat.unused
+import cats.effect.Bracket
+import tofu.Finally
+import tofu.kernel.types._
+import cats.effect.ExitCase
 
 object CE2Kernel {
   def delayViaSync[K[_]](implicit KS: Sync[K]): Delay[K] =
@@ -33,4 +37,17 @@ object CE2Kernel {
     override def timeoutTo[A](fa: F[A], after: FiniteDuration, fallback: F[A]): F[A] =
       Concurrent.timeoutTo(fa, after, fallback)
   }
+  
+  final implicit def finallyFromBracket[F[_], E](implicit F: Bracket[F, E]): Finally[F, TConst[ExitCase[E], *]] =
+    new Finally[F, TConst[ExitCase[E], *]] {
+      def finallyCase[A, B, C](init: F[A])(action: A => F[B])(release: (A, ExitCase[E]) => F[C]): F[B] =
+        F.bracketCase(init)(action) { case (a, exit) =>
+          F.void(release(a, exit))
+        }
+      def bracket[A, B, C](init: F[A])(action: A => F[B])(release: (A, Boolean) => F[C]): F[B]         =
+        F.bracketCase(init)(action) {
+          case (a, ExitCase.Completed) => F.void(release(a, true))
+          case (a, _)                  => F.void(release(a, false))
+        }
+    }
 }


### PR DESCRIPTION
This one is tricky. 
We had to use whitebox macros to allow optional instance to derive type that may be unconstructable in the using code and shapeless Aux encoding for intermediate carrier .