### PR TITLE
Context typeclasses

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,8 +347,7 @@ lazy val scalacWarningConfig = scalacOptions += {
 
   // print warning category for fine-grained suppressing, e.g. @nowarn("cat=unused-params")
   val contextDeprecationInfo = "cat=deprecation&msg=^(.*((Has)|(With)).*)$:info"
-  val verboseWarnings = "any:wv"
-  
+  val verboseWarnings        = "any:wv"
 
   s"-Wconf:$contextDeprecationInfo,$verboseWarnings"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ lazy val defaultSettings = Seq(
   setMinorVersion,
   setModuleName,
   defaultScalacOptions,
-  Test / scalacOptions += "-Wconf:cat=deprecation:info,any:wv",
   scalacWarningConfig,
   libraryDependencies ++= Seq(
     compilerPlugin(kindProjector),
@@ -347,9 +346,11 @@ lazy val scalacWarningConfig = scalacOptions += {
   // }.mkString(",")
 
   // print warning category for fine-grained suppressing, e.g. @nowarn("cat=unused-params")
+  val contextDeprecationInfo = "cat=deprecation&msg=^(.*((Has)|(With)).*)$:info"
   val verboseWarnings = "any:wv"
+  
 
-  s"-Wconf:$verboseWarnings"
+  s"-Wconf:$contextDeprecationInfo,$verboseWarnings"
 }
 
 lazy val macros = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val defaultSettings = Seq(
   setMinorVersion,
   setModuleName,
   defaultScalacOptions,
+  Test / scalacOptions += "-Wconf:cat=deprecation:info,any:wv",
   scalacWarningConfig,
   libraryDependencies ++= Seq(
     compilerPlugin(kindProjector),

--- a/kernel/src/main/scala/tofu/Context.scala
+++ b/kernel/src/main/scala/tofu/Context.scala
@@ -1,16 +1,10 @@
 package tofu
 
-import cats.data.ReaderT
 import cats.{Applicative, FlatMap, Functor, ~>}
-import tofu.lift.{Lift, Unlift}
+import tofu.internal.ContextBase
+import tofu.kernel.types._
 import tofu.optics.{Contains, Equivalent, Extract}
 import tofu.syntax.funk._
-import cats.Monad
-import tofu.kernel.types._
-import cats.arrow.FunctionK
-import tofu.internal.ContextBase
-import tofu.syntax.monadic._
-import tofu.internal.carriers.UnliftEffect
 
 /** Declares that [[F]] can provide value of type  Ctx
   *

--- a/kernel/src/main/scala/tofu/Has.scala
+++ b/kernel/src/main/scala/tofu/Has.scala
@@ -1,0 +1,30 @@
+package tofu
+
+import cats.Monad
+import cats.data.ReaderT
+import tofu.internal.ContextBase
+import tofu.internal.carriers.UnliftEffect
+import tofu.kernel.types.{HasContext, HasContextRun, HasLocal, HasProvide}
+import tofu.lift.Unlift
+
+@deprecated("Use WithContext instead", "0.10.3")
+object HasContext {
+  def apply[F[_], C](implicit hc: HasContext[F, C]): HasContext[F, C] = hc
+}
+
+@deprecated("Use WithLocal instead", "0.10.3")
+object HasLocal {
+  def apply[F[_], C](implicit hl: HasLocal[F, C]): HasLocal[F, C] = hl
+}
+
+@deprecated("Use WithProvide instead", "0.10.3")
+object HasProvide {
+  def apply[F[_], G[_], C](implicit hp: HasProvide[F, G, C]): HasProvide[F, G, C] = hp
+}
+
+@deprecated("Use WithRun instead", "0.10.3")
+object HasContextRun {
+  def apply[F[_], G[_], C](implicit hcr: HasContextRun[F, G, C]): HasContextRun[F, G, C] = hcr
+}
+
+

--- a/kernel/src/main/scala/tofu/Has.scala
+++ b/kernel/src/main/scala/tofu/Has.scala
@@ -1,11 +1,6 @@
 package tofu
 
-import cats.Monad
-import cats.data.ReaderT
-import tofu.internal.ContextBase
-import tofu.internal.carriers.UnliftEffect
 import tofu.kernel.types.{HasContext, HasContextRun, HasLocal, HasProvide}
-import tofu.lift.Unlift
 
 @deprecated("Use WithContext instead", "0.10.3")
 object HasContext {

--- a/kernel/src/main/scala/tofu/WithContext.scala
+++ b/kernel/src/main/scala/tofu/WithContext.scala
@@ -1,0 +1,27 @@
+package tofu
+
+import cats.Functor
+import tofu.optics.Contains
+
+/** Synonym for [[Context]] with explicit C as Ctx for better type inference
+  *
+  * There is also a nice type alias: {{{
+  * import tofu.In
+  *
+  * val fHasMyCtx: MyCtx In F = ???
+  * }}}
+  */
+trait WithContext[F[_], C] extends Context[F] {
+  override type Ctx = C
+}
+
+/** Companion object for [[WithContext]] */
+object WithContext {
+  def apply[F[_], C](implicit ctx: WithContext[F, C]): WithContext[F, C] = ctx
+}
+
+final class WithContextContainsInstance[F[_], A, B](implicit wc: WithContext[F, A], lens: A Contains B)
+  extends WithContext[F, B] {
+  def functor: Functor[F] = wc.functor
+  def context: F[B]       = wc.extract(lens).context
+}

--- a/kernel/src/main/scala/tofu/WithLocal.scala
+++ b/kernel/src/main/scala/tofu/WithLocal.scala
@@ -1,0 +1,9 @@
+package tofu
+
+/** Synonym for [[Local]] with explicit C as Ctx for better type inference */
+trait WithLocal[F[_], C] extends Local[F] with WithContext[F, C]
+
+/** Companion object for [[WithLocal]] */
+object WithLocal {
+  def apply[F[_], C](implicit ctx: WithLocal[F, C]): WithLocal[F, C] = ctx
+}

--- a/kernel/src/main/scala/tofu/WithProvide.scala
+++ b/kernel/src/main/scala/tofu/WithProvide.scala
@@ -1,0 +1,19 @@
+package tofu
+
+import tofu.lift.Lift
+
+/** Synonym for [[Provide]] with explicit `C` as `Ctx` and `G` as `Lower` for better type inference
+  *
+  * Can be seen as transformation `F[*] = C => G[*]`
+  */
+trait WithProvide[F[_], G[_], C] extends Provide[F] with Lift[G, F] {
+  override type Lower[A] = G[A]
+  override type Ctx = C
+
+  def self = this
+}
+
+/** Companion object for [[WithProvide]] */
+object WithProvide {
+  def apply[F[_], G[_], C](implicit p: WithProvide[F, G, C]): WithProvide[F, G, C] = p
+}

--- a/kernel/src/main/scala/tofu/WithRun.scala
+++ b/kernel/src/main/scala/tofu/WithRun.scala
@@ -1,0 +1,18 @@
+package tofu
+
+import tofu.lift.Unlift
+
+/** Synonym for both [[RunContext]] and [[Unlift]] with explicit `C` as `Ctx` and `G` as `Lower` for better type inference
+  *
+  * Can be seen as transformation `F[*] = C => G[*]`
+  */
+trait WithRun[F[_], G[_], C] extends WithProvide[F, G, C] with WithLocal[F, C] with RunContext[F] with Unlift[G, F] {
+  override type Ctx = C
+
+  override def self = this
+}
+
+/** Companion object for [[WithRun]] */
+object WithRun {
+  def apply[F[_], G[_], C](implicit ctx: WithRun[F, G, C]): WithRun[F, G, C] = ctx
+}

--- a/kernel/src/main/scala/tofu/internal/ContextBase.scala
+++ b/kernel/src/main/scala/tofu/internal/ContextBase.scala
@@ -1,0 +1,47 @@
+package tofu.internal
+
+
+import cats.data.ReaderT
+import cats.{Applicative, FlatMap, Functor, ~>}
+import tofu.lift.{Lift, Unlift}
+import tofu.optics.{Contains, Equivalent, Extract}
+import tofu.syntax.funk._
+import cats.Monad
+import tofu.kernel.types._
+import cats.arrow.FunctionK
+import tofu.internal.ContextBase
+import tofu.syntax.monadic._
+import tofu.internal.carriers.UnliftEffect
+import tofu.WithRun
+
+/** Common base for instances */
+trait ContextBase
+
+object ContextBase extends ContextBaseInstances1 {
+  implicit def unliftIdentity[F[_] : Applicative]: Unlift[F, F] = new Unlift[F, F] {
+    def lift[A](fa: F[A]): F[A] = fa
+
+    def unlift: F[F ~> F] = FunctionK.id[F].pure[F]
+  }
+
+  final implicit def readerTContext[F[_] : Applicative, C]: WithRun[ReaderT[F, C, *], F, C] =
+    new WithRun[ReaderT[F, C, *], F, C] {
+      def lift[A](fa: F[A]): ReaderT[F, C, A] = ReaderT.liftF(fa)
+
+      def runContext[A](fa: ReaderT[F, C, A])(ctx: C): F[A] = fa.run(ctx)
+
+      def local[A](fa: ReaderT[F, C, A])(project: C => C): ReaderT[F, C, A] = fa.local(project)
+
+      val functor: Functor[ReaderT[F, C, *]] = Functor[ReaderT[F, C, *]]
+      val context: ReaderT[F, C, C] = ReaderT.ask[F, C]
+    }
+}
+trait ContextBaseInstances1 extends ContextBaseInstances2 {
+  final implicit def unliftReaderCompose[F[_]: Monad, G[_], R](implicit FG: Unlift[G, F]): Unlift[G, ReaderT[F, R, *]] =
+    FG.andThen(ContextBase.readerTContext[F, R])
+}
+
+trait ContextBaseInstances2 {
+  final implicit def unliftIOEffect[F[_], G[_]](implicit carrier: UnliftEffect[F, G]): Unlift[F, G] =
+    carrier.value
+}

--- a/kernel/src/main/scala/tofu/internal/ContextBase.scala
+++ b/kernel/src/main/scala/tofu/internal/ContextBase.scala
@@ -1,18 +1,13 @@
 package tofu.internal
 
 
-import cats.data.ReaderT
-import cats.{Applicative, FlatMap, Functor, ~>}
-import tofu.lift.{Lift, Unlift}
-import tofu.optics.{Contains, Equivalent, Extract}
-import tofu.syntax.funk._
-import cats.Monad
-import tofu.kernel.types._
 import cats.arrow.FunctionK
-import tofu.internal.ContextBase
-import tofu.syntax.monadic._
-import tofu.internal.carriers.UnliftEffect
+import cats.data.ReaderT
+import cats.{Applicative, Functor, Monad, ~>}
 import tofu.WithRun
+import tofu.internal.carriers.UnliftEffect
+import tofu.lift.Unlift
+import tofu.syntax.monadic._
 
 /** Common base for instances */
 trait ContextBase

--- a/kernel/src/main/scala/tofu/kernel/types.scala
+++ b/kernel/src/main/scala/tofu/kernel/types.scala
@@ -9,12 +9,16 @@ object types extends KernelTypes
 trait KernelTypes extends Any {
   type In[C, F[_]] = WithContext[F, C]
 
+  @deprecated("Use WithContext instead", "0.10.3")
   type HasContext[F[_], C] = Context[F] { type Ctx = C }
 
+  @deprecated("Use WithLocal instead", "0.10.3")
   type HasLocal[F[_], C] = Local[F] { type Ctx = C }
 
+  @deprecated("Use WithProvide instead", "0.10.3")
   type HasProvide[F[_], G[_], C] = WithProvide[F, G, C]
 
+  @deprecated("Use WithRun instead", "0.10.3")
   type HasContextRun[F[_], G[_], C] = WithRun[F, G, C]
 
   type AnyK[_] = Any

--- a/kernel/src/main/scala/tofu/lift/Unlift.scala
+++ b/kernel/src/main/scala/tofu/lift/Unlift.scala
@@ -8,6 +8,7 @@ import syntax.funk._
 import tofu.optics.Contains
 import tofu.syntax.monadic._
 import kernel.types._
+import tofu.internal.ContextBase
 
 trait Lift[F[_], G[_]] {
   def lift[A](fa: F[A]): G[A]


### PR DESCRIPTION
This PR moves WithContext, WithLocal, WithProvide, and WithRun from `Context.scala`.
Also, it marks HasContext and others as deprecated.

I was trying to keep this PR as simple as possible so it's kinda small.
