### PR TITLE
Use kernel dependency for derivation, zioCore and streams modules.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val coreCatsMtlInterop = project
     name := "tofu-core-cats-mtl",
     libraryDependencies += catsMtl
   )
-  .dependsOn(core)
+  .dependsOn(kernel)
 
 lazy val memo = project
   .in(file("modules/memo"))
@@ -245,7 +245,7 @@ lazy val derivation =
       libraryDependencies ++= Seq(magnolia, derevo, catsTagless),
       name := "tofu-derivation",
     )
-    .dependsOn(core)
+    .dependsOn(kernel)
 
 lazy val zioCore =
   project
@@ -297,7 +297,7 @@ lazy val streams = project
     defaultSettings,
     name := "tofu-streams",
   )
-  .dependsOn(core)
+  .dependsOn(kernel)
 
 lazy val coreModules =
   Vector(

--- a/modules/derivation/src/main/scala/tofu/higherKind/derived/ContextEmbed.scala
+++ b/modules/derivation/src/main/scala/tofu/higherKind/derived/ContextEmbed.scala
@@ -1,10 +1,10 @@
 package tofu.higherKind.derived
 import cats.FlatMap
-import tofu.HasContext
 import tofu.bi.TwinContext
 import tofu.control.Bind
 import tofu.higherKind.Embed
 import tofu.higherKind.bi.EmbedBK
+import tofu.kernel.types.HasContext
 
 /** simple mixin for typeclass companion
   * to add contextual embedded instance


### PR DESCRIPTION
Apparently, those modules are not using anything from `core`.