### PR TITLE
Update fs2Instances package to ce3

### DIFF
--- a/modules/fs2/src/main/scala/tofu/fs2/implicits.scala
+++ b/modules/fs2/src/main/scala/tofu/fs2/implicits.scala
@@ -1,0 +1,7 @@
+package tofu.fs2
+
+object implicits extends Fs2Instances1 with Fs2Syntax
+
+object LiftStream {
+  def apply[S[_], F[_]](implicit ev: LiftStream[S, F]): LiftStream[S, F] = ev
+}

--- a/modules/fs2/src/main/scala/tofu/fs2/package.scala
+++ b/modules/fs2/src/main/scala/tofu/fs2/package.scala
@@ -4,10 +4,5 @@ import _root_.fs2.Stream
 import tofu.lift.Lift
 
 package object fs2 {
-
   type LiftStream[S[_], F[_]] = Lift[Stream[F, *], S]
-
-  object LiftStream {
-    def apply[S[_], F[_]](implicit ev: LiftStream[S, F]): LiftStream[S, F] = ev
-  }
 }

--- a/modules/fs2/src/main/scala/tofu/fs2/preSyntax.scala
+++ b/modules/fs2/src/main/scala/tofu/fs2/preSyntax.scala
@@ -1,0 +1,15 @@
+package tofu.fs2
+
+import cats.tagless.ApplyK
+import fs2.Stream
+import tofu.higherKind.Pre.T
+import tofu.syntax.funk.funK
+
+trait Fs2Syntax {
+  implicit def ops[F[_], U[f[_]]](self: U[T[F, *]]): TofuPreStreamSyntax[F, U] = new TofuPreStreamSyntax(self)
+}
+
+private final class TofuPreStreamSyntax[F[_], U[f[_]]](private val self: U[T[F, *]]) extends AnyVal {
+  def attachStream(alg: U[Stream[F, *]])(implicit U: ApplyK[U]): U[Stream[F, *]] =
+    U.map2K(self, alg)(funK(t2k => Stream.exec(t2k.first.value) ++ t2k.second))
+}

--- a/modules/fs2/src/main/scala/tofu/fs2/syntax.scala
+++ b/modules/fs2/src/main/scala/tofu/fs2/syntax.scala
@@ -1,0 +1,3 @@
+package tofu.fs2
+
+object syntax extends Fs2Syntax

--- a/modules/fs2/src/main/scala/tofu/fs2Instances/package.scala
+++ b/modules/fs2/src/main/scala/tofu/fs2Instances/package.scala
@@ -1,3 +1,6 @@
 package tofu
 
+import tofu.fs2.Fs2Instances1
+
+//@deprecated("Use tofu.fs2.implicits instead", "0.11.0")
 package object fs2Instances extends Fs2Instances1

--- a/modules/fs2/src/main/scala/tofu/fs2Syntax/pre.scala
+++ b/modules/fs2/src/main/scala/tofu/fs2Syntax/pre.scala
@@ -2,12 +2,9 @@ package tofu.fs2Syntax
 
 import cats.tagless.ApplyK
 import fs2.Stream
+import tofu.fs2.Fs2Syntax
 import tofu.higherKind.Pre.T
 import tofu.syntax.funk.funK
 
-object pre {
-  implicit final class TofuPreStreamSyntax[F[_], U[f[_]]](private val self: U[T[F, *]]) extends AnyVal {
-    def attachStream(alg: U[Stream[F, *]])(implicit U: ApplyK[U]): U[Stream[F, *]] =
-      U.map2K(self, alg)(funK(t2k => Stream.eval_(t2k.first.value) ++ t2k.second))
-  }
-}
+@deprecated("Use tofu.fs2.syntax or tofu.fs2.implicits instead", "0.11.0")
+object pre extends Fs2Syntax

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 
     val cats = "2.6.1"
 
-    val catsEffect = "2.5.1"
+    val catsEffect = "3.1.1"
 
     val catsMtl = "1.2.1"
 
@@ -30,7 +30,7 @@ object Dependencies {
 
     val slf4j = "1.7.31"
 
-    val fs2 = "2.5.9"
+    val fs2 = "3.0.6"
 
     val logback = "1.2.3"
 
@@ -44,13 +44,13 @@ object Dependencies {
 
     val zio = "1.0.9"
 
-    val zioCats = "2.5.1.0"
+    val zioCats = "3.1.1.0"
 
     val shapeless = "2.3.7"
 
     val refined = "0.9.26"
 
-    val doobie = "0.13.4"
+    val doobie = "1.0.0-M5"
 
     // Compile time only
     val macroParadise = "2.1.1"


### PR DESCRIPTION
This PR updates fs2 version and so that updates ce3 version.
I expect some other PR to do version update the right way, while this one focuses solely on the update of fs2Instances package.

Also this PR should target another branch specific for ce3-migration. I'll edit this when this branch is created.
