### PR TITLE
Exclude http4s from .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,5 +2,8 @@ updates.pin = [
   {groupId = "org.typelevel", artifactId = "cats-effect", version = "2."},
   {groupId = "org.typelevel", artifactId = "log4cats-core", version = "1."},
   {groupId = "co.fs2", artifactId = "fs2-io", version = "2."},
-  {groupId = "dev.zio", artifactId = "zio-interop-cats", version = "2."} 
+  {groupId = "dev.zio", artifactId = "zio-interop-cats", version = "2."},
+  {groupId = "org.http4s", artifactId = "http4s-dsl", version = "0.22."},
+  {groupId = "org.http4s", artifactId = "http4s-circe", version = "0.22."},
+  {groupId = "org.http4s", artifactId = "http4s-blaze-server", version = "0.22."}
 ]


### PR DESCRIPTION
Until we move to ce3 completely