### PR TITLE
Implicit conversion from Bind to cats.Monad

### DIFF
--- a/modules/higherKindCore/src/main/scala/tofu/instances/bind.scala
+++ b/modules/higherKindCore/src/main/scala/tofu/instances/bind.scala
@@ -1,0 +1,8 @@
+package tofu.instances
+
+import cats.Monad
+import tofu.control.Bind
+
+object bind {
+  implicit def monadFromBind[F[+_, +_], E](implicit bind: Bind[F]): Monad[F[E, *]] = bind.monad
+}

--- a/modules/higherKindCore/src/test/scala/tofu/control/CatsInstancesFromBindSuite.scala
+++ b/modules/higherKindCore/src/test/scala/tofu/control/CatsInstancesFromBindSuite.scala
@@ -1,6 +1,6 @@
 package tofu.control
 
-import cats.FlatMap
+import cats.{Applicative, FlatMap}
 import tofu.compat.unused
 import tofu.instances.bind._
 
@@ -10,7 +10,7 @@ class CatsInstancesFromBindSuite {
     requireFlatMap[F[Nothing, *]]
   }
 
-  def requireApplicative[F[_]](implicit @unused applicative: FlatMap[F]): Unit = ()
+  def requireApplicative[F[_]](implicit @unused applicative: Applicative[F]): Unit = ()
 
-  def requireFlatMap[F[_]](implicit @unused applicative: FlatMap[F]): Unit = ()
+  def requireFlatMap[F[_]](implicit @unused flatMap: FlatMap[F]): Unit = ()
 }

--- a/modules/higherKindCore/src/test/scala/tofu/control/CatsInstancesFromBindSuite.scala
+++ b/modules/higherKindCore/src/test/scala/tofu/control/CatsInstancesFromBindSuite.scala
@@ -1,0 +1,16 @@
+package tofu.control
+
+import cats.FlatMap
+import tofu.compat.unused
+import tofu.instances.bind._
+
+class CatsInstancesFromBindSuite {
+  def summonBindInstances[F[+_, +_]](implicit bind: Bind[F]): Unit = {
+    requireApplicative[F[Throwable, *]]
+    requireFlatMap[F[Nothing, *]]
+  }
+
+  def requireApplicative[F[_]](implicit @unused applicative: FlatMap[F]): Unit = ()
+
+  def requireFlatMap[F[_]](implicit @unused applicative: FlatMap[F]): Unit = ()
+}


### PR DESCRIPTION
From user perspective, when I require Bind instance in my code,
I want to have implicit cats.Monad instance for later usages. Now to do so
I have to write something like implicit def monad[E] = bind.monad[E]
in the beginning of the method, since most of the library methods accept
typeclasses as implicit parameters.

Assuming that Bind is right-biased, it makes perfect sense to write such
implicit conversion and use it in source file imports section.