### PR TITLE
zio-logging:  add writeMarkerCause, fix zio doc references

### DIFF
--- a/docs/tofu.logging.recipes.zio.md
+++ b/docs/tofu.logging.recipes.zio.md
@@ -73,7 +73,7 @@ object BarService {
 ```
 
 What can we learn from this code?
-1. According to ZIO [Module Pattern 2.0](https://zio.dev/docs/datatypes/contextual/index#module-pattern-20) 
+1. According to ZIO [Module Pattern 2.0](https://zio.dev/1.x/datatypes/contextual/index#module-pattern-20) 
 class constructors are used to define service dependencies. At the end of the day the class constructor
 is lifted to ZLayer: `(new BarServiceImpl(_, _)).toLayer`
 2. `TofuLogs` is a type alias for `Has[ZLogging.Make]`, but ZIO encourages us to use explicitly the `Has` wrapper 
@@ -139,9 +139,9 @@ Here we use [Tofu Derevo](https://github.com/tofu-tf/derevo) for automatic deriv
 One possible way to add a context to your logs is to use `layerPlainWithContext` which encapsulates dealing with the context inside
 (otherwise you can use `layerContextual` retrieving the context from a ZIO environment `R`, but we won't cover it here).
 
-The main idea of this approach is to store your context in ZIO [FiberRef](https://zio.dev/docs/datatypes/fiber/fiberref). 
+The main idea of this approach is to store your context in ZIO [FiberRef](https://zio.dev/1.x/datatypes/fiber/fiberref). 
 It provides all the power of State Monad. Unlike Java's `ThreadLocal`, `FiberRef` has copy-on-fork semantic: 
-a child [Fiber](https://zio.dev/docs/datatypes/fiber/fiber/) starts with `FiberRef` values of its parent.
+a child [Fiber](https://zio.dev/1.x/datatypes/fiber/fiber/) starts with `FiberRef` values of its parent.
 When the child set a new value of FiberRef, the change is visible only to the child itself. This means if we set `requestId` value to `117`
 (e.g. at the start of the request) and pass the `FiberRef` to a child fiber, it sees the value `117`.
 

--- a/modules/logging/layout/src/test/resources/logback-test.xml
+++ b/modules/logging/layout/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<configuration debug="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</configuration>

--- a/modules/logging/layout/src/test/scala/tofu/logging/LogbackSuite.scala
+++ b/modules/logging/layout/src/test/scala/tofu/logging/LogbackSuite.scala
@@ -1,0 +1,42 @@
+package tofu.logging
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory
+import tofu.{Delay, WithContext}
+
+import scala.jdk.CollectionConverters._
+
+class LogbackSuite extends AnyFunSuite {
+  type Ctx = Map[String, String]
+  implicit val delay: Delay[Ctx => *] = new Delay[Ctx => *] {
+    def delay[A](a: => A) = _ => a
+  }
+
+  implicit val context: WithContext[Ctx => *, Ctx] = WithContext.make(identity)
+
+  implicit val logs: Logging.Make[Ctx => *] = Logging.Make.contextual[Ctx => *, Ctx]
+
+  val appender = new ListAppender[ILoggingEvent]
+
+  val logger = LoggerFactory.getLogger(this.getClass()).asInstanceOf[Logger]
+  println(logger.iteratorForAppenders.asScala.toList)
+  appender.start()
+  logger.addAppender(appender)
+
+  val logging = logs.forService[LogbackSuite]
+  test("throwable sent as throwable") {
+
+    val error = new Exception("Wild Effect Appeared")
+
+    logging.debugCause("Hello", error, Map("oh" -> "noo"))(Map("ehm" -> "umm"))
+
+    Thread.sleep(100)
+
+    val first = appender.list.asScala.head.getThrowableProxy()
+    assert(first.getMessage === "Wild Effect Appeared")
+    assert(first.getClassName === classOf[Exception].getName)
+  }
+}

--- a/modules/logging/layout/src/test/scala/tofu/logging/LogbackSuite.scala
+++ b/modules/logging/layout/src/test/scala/tofu/logging/LogbackSuite.scala
@@ -22,7 +22,6 @@ class LogbackSuite extends AnyFunSuite {
   val appender = new ListAppender[ILoggingEvent]
 
   val logger = LoggerFactory.getLogger(this.getClass()).asInstanceOf[Logger]
-  println(logger.iteratorForAppenders.asScala.toList)
   appender.start()
   logger.addAppender(appender)
 

--- a/modules/logging/structured/src/main/scala/tofu/logging/impl/UniversalLogging.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/impl/UniversalLogging.scala
@@ -38,6 +38,37 @@ object UniversalLogging {
       case Warn  => logger.warn(marker, message, values: _*)
       case Error => logger.error(marker, message, values: _*)
     }
+
+  private[impl] final def writeCause(
+      level: Logging.Level,
+      logger: Logger,
+      cause: Throwable,
+      message: String,
+      values: Seq[LoggedValue]
+  ): Unit =
+    level match {
+      case Trace => logger.trace(message, values :+ cause: _*)
+      case Debug => logger.debug(message, values :+ cause: _*)
+      case Info  => logger.info(message, values :+ cause: _*)
+      case Warn  => logger.warn(message, values :+ cause: _*)
+      case Error => logger.error(message, values :+ cause: _*)
+    }
+
+  private[impl] final def writeMarkerCause(
+      level: Logging.Level,
+      logger: Logger,
+      marker: Marker,
+      cause: Throwable,
+      message: String,
+      values: Seq[LoggedValue]
+  ): Unit =
+    level match {
+      case Trace => logger.trace(marker, message, values :+ cause: _*)
+      case Debug => logger.debug(marker, message, values :+ cause: _*)
+      case Info  => logger.info(marker, message, values :+ cause: _*)
+      case Warn  => logger.warn(marker, message, values :+ cause: _*)
+      case Error => logger.error(marker, message, values :+ cause: _*)
+    }
 }
 
 class UniversalLogging[F[_]](name: String)(implicit F: Delay[F]) extends Logging[F] {

--- a/modules/logging/structured/src/main/scala/tofu/logging/impl/UniversalLogging.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/impl/UniversalLogging.scala
@@ -85,6 +85,13 @@ class UniversalLogging[F[_]](name: String)(implicit F: Delay[F]) extends Logging
       if (UniversalLogging.enabled(level, logger))
         UniversalLogging.writeMarker(level, logger, marker, message, values)
     }
+
+  override def writeCause(level: Logging.Level, message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    F.delay {
+      val logger = LoggerFactory.getLogger(name)
+      if (UniversalLogging.enabled(level, logger))
+        UniversalLogging.writeCause(level, logger, cause, message, values)
+    }
 }
 
 class UniversalContextLogging[F[_]](name: String, fctx: (LoggedValue => Unit) => F[Unit]) extends Logging[F] {
@@ -93,6 +100,13 @@ class UniversalContextLogging[F[_]](name: String, fctx: (LoggedValue => Unit) =>
       val logger = LoggerFactory.getLogger(name)
       if (UniversalLogging.enabled(level, logger))
         UniversalLogging.writeMarker(level, logger, ContextMarker(ctx), message, values)
+    }
+
+  override def writeCause(level: Logging.Level, message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    fctx { ctx =>
+      val logger = LoggerFactory.getLogger(name)
+      if (UniversalLogging.enabled(level, logger))
+        UniversalLogging.writeMarkerCause(level, logger, ContextMarker(ctx), cause, message, values)
     }
 
   override def writeMarker(level: Logging.Level, message: String, marker: Marker, values: LoggedValue*): F[Unit] =

--- a/modules/zio/logging/src/main/scala/tofu/logging/impl/ZUniversalContextLogging.scala
+++ b/modules/zio/logging/src/main/scala/tofu/logging/impl/ZUniversalContextLogging.scala
@@ -22,4 +22,18 @@ class ZUniversalContextLogging[R, C: Loggable](name: String, ctxLog: URIO[R, C])
           UniversalLogging.writeMarker(level, logger, ContextMarker(ctx, List(marker)), message, values)
       }
     }
+
+  override def writeCause(
+      level: Logging.Level,
+      message: String,
+      cause: Throwable,
+      values: LoggedValue*
+  ): URIO[R, Unit] =
+    ctxLog.flatMap { ctx =>
+      ZIO.effectTotal {
+        val logger = LoggerFactory.getLogger(name)
+        if (UniversalLogging.enabled(level, logger))
+          UniversalLogging.writeMarkerCause(level, logger, ContextMarker(ctx), cause, message, values)
+      }
+    }
 }

--- a/modules/zio/logging/src/main/scala/tofu/logging/impl/ZUniversalLogging.scala
+++ b/modules/zio/logging/src/main/scala/tofu/logging/impl/ZUniversalLogging.scala
@@ -18,4 +18,11 @@ class ZUniversalLogging(name: String) extends Logging[UIO] {
       if (UniversalLogging.enabled(level, logger))
         UniversalLogging.writeMarker(level, logger, marker, message, values)
     }
+
+  override def writeCause(level: Logging.Level, message: String, cause: Throwable, values: LoggedValue*): UIO[Unit] =
+    ZIO.effectTotal {
+      val logger = LoggerFactory.getLogger(name)
+      if (UniversalLogging.enabled(level, logger))
+        UniversalLogging.writeCause(level, logger, cause, message, values)
+    }
 }

--- a/modules/zio/logging/src/main/scala/tofu/logging/zlogs/ZLogging.scala
+++ b/modules/zio/logging/src/main/scala/tofu/logging/zlogs/ZLogging.scala
@@ -3,6 +3,8 @@ package tofu.logging.zlogs
 import tofu.logging.impl.{ZUniversalContextLogging, ZUniversalLogging}
 import tofu.logging.{Loggable, Logging}
 import zio._
+import zio.interop.catz._
+
 import scala.annotation.unused
 
 object ZLogging {
@@ -36,5 +38,7 @@ object ZLogging {
         new ZUniversalContextLogging[Any, Ctx](_, getContext(cs))
       }
     }
+
+    val layerEmpty: ULayer[Has[ZLogging.Make]] = ZLayer.succeed(_ => Logging.empty[UIO])
   }
 }


### PR DESCRIPTION
When <level>Cause method is called the exception is wrapped in `tofu.logging.LoggedThrowable`. The PR fixes this unwanted behavior. 
Also references to the zio website are updated.