### PR TITLE
ComposedLoggedValue: single LoggedValue as several LoggedValues on the top-level

### DIFF
--- a/modules/logging/structured/src/main/scala/tofu/logging/LoggedValue.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/LoggedValue.scala
@@ -1,5 +1,8 @@
 package tofu.logging
 
+import cats.kernel.Semigroup
+import tofu.logging.impl.ComposedLoggedValue
+
 import scala.{specialized => sp}
 
 trait LoggedValue {
@@ -30,6 +33,10 @@ object LoggedValue {
   implicit def loggableToLoggedValue[A](x: A)(implicit loggable: Loggable[A]): LoggedValue = loggable.loggedValue(x)
 
   def error(cause: Throwable): LoggedThrowable = new LoggedThrowable(cause)
+
+  implicit val loggedValueSemigroup: Semigroup[LoggedValue] = Semigroup.instance { (a, b) =>
+    new ComposedLoggedValue(a :: b :: Nil)
+  }
 }
 
 final class LoggedThrowable(cause: Throwable) extends Throwable(cause.getMessage, cause) with LoggedValue {

--- a/modules/logging/structured/src/main/scala/tofu/logging/impl/ComposedLoggedValue.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/impl/ComposedLoggedValue.scala
@@ -1,0 +1,16 @@
+package tofu.logging.impl
+
+import tofu.logging.{LogRenderer, LoggedValue}
+
+/** This is supposed to be used to log several `LoggedValue` as if they were passed as arguments to the logging method.
+  * E.g. to provide single `LoggedValue` into `ContextMarker`. Be careful: the resulting structured log may contain the
+  * same fields.
+  */
+class ComposedLoggedValue(values: Iterable[LoggedValue]) extends LoggedValue {
+  override def toString: String = values.map(_.toString).mkString(", ")
+
+  override def logFields[I, V, @specialized R, @specialized M](input: I)(implicit r: LogRenderer[I, V, R, M]): R =
+    values.foldLeft(r.noop(input)) { (acc, value) =>
+      r.combine(acc, value.logFields(input))
+    }
+}


### PR DESCRIPTION
ContextMarker allows to provide only single LoggedValue. 

Writing ZIO2 logger I faced that I need to collect context (several LoggedValues) from different places (zio-annotations, zio-spans, user-defined context) and put it into ContextMarker. This several logged values (potentially named or constructed from Map[String, A]) must be logged as if they provided in arguments of logging-method.