### PR TITLE
Using unsafe FiberRef constuctor available in zio 2.0.6

### DIFF
--- a/modules/interop/zio2/logging/src/main/scala-2/tofu/logging/zlogs/TofuDefaultContext.scala
+++ b/modules/interop/zio2/logging/src/main/scala-2/tofu/logging/zlogs/TofuDefaultContext.scala
@@ -21,11 +21,7 @@ object TofuDefaultContext {
     * `zio.logging#logContext`.
     */
   private[logging] lazy val AnnotatedContextRef: FiberRef[Map[LogAnnotation[_], Any]] =
-    Unsafe.unsafe(implicit unsafe =>
-      Runtime.default.unsafe
-        .run(ZIO.scoped(FiberRef.make[Map[LogAnnotation[_], Any]](Map.empty)))
-        .getOrThrow()
-    )
+    Unsafe.unsafe(implicit unsafe => FiberRef.unsafe.make[Map[LogAnnotation[_], Any]](Map.empty))
 
   private[logging] def getValueUnsafe[A](key: LogAnnotation[A])(m: Map[LogAnnotation[_], Any]): Option[A] =
     m.get(key).asInstanceOf[Option[A]]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
 
     val zio = "1.0.17"
 
-    val zio2 = "2.0.5"
+    val zio2 = "2.0.6"
 
     val zioCats = "2.5.1.0"
 


### PR DESCRIPTION
Workaround with effectfull FiberRef constuctor used earlier was fixed #1086.
PR includes ZIO 2.0.6 update commit from @Tofu-bot.