### PR TITLE
docs: cats-effect interop moved to tofu-core-* modules

### DIFF
--- a/docs/tofu.logging.home.md
+++ b/docs/tofu.logging.home.md
@@ -22,13 +22,13 @@ according package:
 Cats Effect 3 users should add the following dependency:
 
 ```sbt
-libraryDependencies += "tf.tofu" %% "tofu-kernel-ce3-interop" % "<latest version in the badge in README>"
+libraryDependencies += "tf.tofu" %% "tofu-core-ce3" % "<latest version in the badge in README>"
 ```
 
 and Cats Effect 2 users should add:
 
 ```sbt
-libraryDependencies += "tf.tofu" %% "tofu-kernel-ce2-interop" % "<latest version in the badge in README>"
+libraryDependencies += "tf.tofu" %% "tofu-core-ce2" % "<latest version in the badge in README>"
 ```
 
 For ZIO users the following is enough:


### PR DESCRIPTION
Interop instances have moved to another module, fix according docs 

Fixes #1128 