### PR TITLE
Fix running `unidoc` and Docusaurus site creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Generate docs
         if: matrix.scala == '2.13'
-        run: sbt ++${{ matrix.scala }} docs/mdoc
+        run: sbt ++${{ matrix.scala }} docs/mdoc unidoc
 
   publish:
     name: Publish Artifacts

--- a/modules/kernel/src/main/scala/tofu/common/Console.scala
+++ b/modules/kernel/src/main/scala/tofu/common/Console.scala
@@ -4,7 +4,7 @@ import tofu.Delay
 import tofu.internal.EffectComp
 
 import java.io.{BufferedReader, PrintStream}
-import scala.Console as ScalaConsole
+import scala.{Console => ScalaConsole}
 
 trait Console[F[_]] {
   def readStrLn: F[String]

--- a/modules/util/env/src/main/scala-2/tofu/env/EnvFunctions.scala
+++ b/modules/util/env/src/main/scala-2/tofu/env/EnvFunctions.scala
@@ -75,9 +75,9 @@ private[env] trait EnvFunctions
   def tailRecM[E, A, B](a: A)(f: (A) => Env[E, Either[A, B]]): Env[E, B] =
     Env(ctx => Task.tailRecM(a)(a1 => f(a1).run(ctx)))
 
-  def when[E](cond: => Boolean)(io: => Env[E, _]): Env[E, Unit] =
+  def when[E](cond: => Boolean)(io: => Env[E, ?]): Env[E, Unit] =
     whenF(delay[E, Boolean](cond))(io)
 
-  def whenF[E](cond: Env[E, Boolean])(io: => Env[E, _]): Env[E, Unit] =
+  def whenF[E](cond: Env[E, Boolean])(io: => Env[E, ?]): Env[E, Unit] =
     cond.flatMap(run => if (run) io.flatMap(_ => Env.unit[E]) else Env.unit[E])
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ logLevel := Level.Warn
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
@@ -12,4 +12,4 @@ addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.1")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ logLevel := Level.Warn
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.2")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 


### PR DESCRIPTION
After migration to project matrix plugin unidoc became broken because source code for all subprojects for different scala version was used to docs compilation (Unidoc plugin feature/bug).

The solution is to generate docs for only main version of scala (now it is 2.13) and to filter out unused subprojects with `unidocProjectFilter` setting.

Now doc commands (`unidoc`, `docusaurusCreateSite`, `docusaurusPublishGhpages`) can be launched in style with or without version specification (on root project) like this:
`unidoc`
`++2.13 unidoc`

Closes #1213