### PR TITLE
fixed zio.Tag's usage in ZIO's WithRun implicit

### DIFF
--- a/modules/interop/zio2/core/src/main/scala/tofu/zioInstances/ZioInstances.scala
+++ b/modules/interop/zio2/core/src/main/scala/tofu/zioInstances/ZioInstances.scala
@@ -46,9 +46,7 @@ private[zioInstances] class ZioInstances {
   private[this] val zioTofuInstanceAny: ZioTofuInstance[Any, Any] = new ZioTofuInstance
   final def zioTofuInstance[R, E]: ZioTofuInstance[R, E]          = zioTofuInstanceAny.asInstanceOf[ZioTofuInstance[R, E]]
 
-  private[this] val zioTofuWithRunInstanceAny                          = new ZioTofuWithRunInstance[Any, Any]
-  final def zioTofuWithRunInstance[R, E]: ZioTofuWithRunInstance[R, E] =
-    zioTofuWithRunInstanceAny.asInstanceOf[ZioTofuWithRunInstance[R, E]]
+  final def zioTofuWithRunInstance[R: Tag, E]: ZioTofuWithRunInstance[R, E] = new ZioTofuWithRunInstance
 
   final def zioTofuUnliftManyInstance[R, E, R1: Tag]: ZioTofuUnliftManyInstance[R, E, R1] =
     new ZioTofuUnliftManyInstance

--- a/modules/interop/zio2/core/src/main/scala/tofu/zioInstances/implicits.scala
+++ b/modules/interop/zio2/core/src/main/scala/tofu/zioInstances/implicits.scala
@@ -39,7 +39,7 @@ private[zioInstances] trait ZioTofuImplicits2 extends ZioTofuImplicits3 {
   @inline final implicit def zioTofuErrorsToImplicit[R, E]: ZioTofuErrorsToInstance[R, E, Nothing] =
     zioTofuErrorsToInstance
   @inline final implicit def zioTofuImplicit[R, E]: ZioTofuInstance[R, E]                          = zioTofuInstance
-  @inline final implicit def zioTofuWithRunImplicit[R, E]: ZioTofuWithRunInstance[R, E]            = zioTofuWithRunInstance
+  @inline final implicit def zioTofuWithRunImplicit[R: Tag, E]: ZioTofuWithRunInstance[R, E]       = zioTofuWithRunInstance
   @inline final implicit def zioTofuBlockingImplicit[R, E]: ZioTofuBlockingInstance[R, E]          =
     zioTofuBlockingInstance[R, E]
 }


### PR DESCRIPTION
- An implicit instance of `Tag` is now used in ZIO's `WithRun` instance to initialize `ZEnvironment` properly.

fixes #1236 