### PR TITLE
feature: Add clockForKleisli and sleepForKleisli

### DIFF
--- a/modules/core/ce2/src/test/scala/tofu/time/TimeSuite.scala
+++ b/modules/core/ce2/src/test/scala/tofu/time/TimeSuite.scala
@@ -34,7 +34,7 @@ class TimeSuite {
     Timeout[ReaderT[IO, Unit, _]]
   }
 
-  def readerF[F[_]: Clock : Sleep] = {
+  def readerF[F[_]: Clock: Sleep] = {
     Clock[ReaderT[F, Unit, _]]
     Sleep[ReaderT[F, Unit, _]]
   }

--- a/modules/core/ce2/src/test/scala/tofu/time/TimeSuite.scala
+++ b/modules/core/ce2/src/test/scala/tofu/time/TimeSuite.scala
@@ -33,4 +33,9 @@ class TimeSuite {
     Sleep[ReaderT[IO, Unit, _]]
     Timeout[ReaderT[IO, Unit, _]]
   }
+
+  def readerF[F[_]: Clock : Sleep] = {
+    Clock[ReaderT[F, Unit, _]]
+    Sleep[ReaderT[F, Unit, _]]
+  }
 }

--- a/modules/core/ce3/src/test/scala/tofu/time/TimeSuite.scala
+++ b/modules/core/ce3/src/test/scala/tofu/time/TimeSuite.scala
@@ -28,4 +28,9 @@ class TimeSuite {
     Sleep[ReaderT[IO, Unit, _]]
     Timeout[ReaderT[IO, Unit, _]]
   }
+
+  def readerF[F[_]: Clock: Sleep] = {
+    Clock[ReaderT[F, Unit, _]]
+    Sleep[ReaderT[F, Unit, _]]
+  }
 }

--- a/modules/kernel/src/main/scala/tofu/time/Sleep.scala
+++ b/modules/kernel/src/main/scala/tofu/time/Sleep.scala
@@ -1,6 +1,7 @@
 package tofu.time
 
 import scala.concurrent.duration.FiniteDuration
+import cats.data.Kleisli
 import tofu.internal.EffectComp
 import tofu.internal.instances.SleepInstance
 
@@ -11,4 +12,7 @@ trait Sleep[F[_]] {
   def sleep(duration: FiniteDuration): F[Unit]
 }
 
-object Sleep extends SleepInstance with EffectComp[Sleep]
+object Sleep extends SleepInstance with EffectComp[Sleep] {
+  implicit def sleepForKleisli[F[_], R](implicit s: Sleep[F]): Sleep[Kleisli[F, R, *]] =
+    (duration: FiniteDuration) => Kleisli.liftF(s.sleep(duration))
+}


### PR DESCRIPTION
Hi, I suggest to add same functionality from cats for effects, so I opened a small pull request to demonstrate what I propose. If it's ok, then in the new PR I'll do it for all transformers and all effects.

Here is an example with a demonstration of the problem: In the first case, with cats everything is fine; in the second case, the ide says that everything is fine, but we get a compilation error.

```scala
  import cats.effect.{Clock => CatsClock}

  // Ok
  def catsClock[F[_]: Monad: CatsClock]: F[FiniteDuration] = {
    val clock = CatsClock[ReaderT[F, String, *]]
    clock.realTime.run("str")
  }

  import tofu.time.{Clock => TofuClock}
  
  // Error `could not find implicit value for parameter e: tofu.time.Clock[[â•¬â”‚$1$]cats.data.Kleisli[F,String,â•¬â”‚$1$]]`
  def tofuClock[F[_]: Monad: TofuClock]: F[Long] = {
    val clock = TofuClock[ReaderT[F, String, *]]
    clock.realTime(SECONDS).run("str")
  }
```