### PR TITLE
Add doubleFlatTap,asIn,asF into EitherFOps

### DIFF
--- a/modules/core/ce2/src/test/scala/tofu/syntax/FEitherSuite.scala
+++ b/modules/core/ce2/src/test/scala/tofu/syntax/FEitherSuite.scala
@@ -250,6 +250,40 @@ class FEitherSuite extends AnyWordSpec with Matchers {
     }
   }
 
+  "EitherFOps#asIn" should {
+
+    "return valid value in case of Right" in {
+      defaultRight.asIn(1) mustBe Some(Right(1))
+    }
+
+    "return Left value without changes" in {
+      defaultLeft.asIn(1) mustBe Some(Left(4))
+    }
+
+    "return valid value in case of base None" in {
+      none[Either[String, Int]].asIn(1) mustBe None
+    }
+  }
+
+  "EitherFOps#asF" should {
+
+    "return valid value in case of Right" in {
+      defaultRight.asF(Some(1)) mustBe Some(Right(1))
+    }
+
+    "return None if inner value is None" in {
+      defaultRight.asF(None) mustBe None
+    }
+
+    "return Left value without changes" in {
+      defaultLeft.asF(Some(1)) mustBe Some(Left(4))
+    }
+
+    "return valid value in case of base None" in {
+      none[Either[String, Int]].asIn(Some(1)) mustBe None
+    }
+  }
+
   "EitherFOps#leftMapF" should {
 
     "return valid value in case of Left" in {
@@ -403,6 +437,26 @@ class FEitherSuite extends AnyWordSpec with Matchers {
       defaultLeft.doubleFlatMap(i => Some(Left(i.length))) mustBe Some(Left(4))
       defaultLeft.doubleFlatMap(i => Some(Right(i.length))) mustBe Some(Left(4))
       defaultLeft.doubleFlatMap(_ => None) mustBe Some(Left(4))
+    }
+  }
+
+  "EitherFOps#doubleFlatTap" should {
+
+    "return None" in {
+      none[Either[String, Int]].doubleFlatTap(_ => None) mustBe None
+      defaultRight.doubleFlatTap(_ => None) mustBe None
+    }
+
+    "return Right without changes" in {
+      defaultRight.doubleFlatTap(i => Some(Right(i + 1))) mustBe defaultRight
+    }
+
+    "return Left" in {
+      defaultRight.doubleFlatTap(i => Some(Left(i.toString))) mustBe Some(Left("4"))
+
+      defaultLeft.doubleFlatTap(i => Some(Left(i.length))) mustBe Some(Left(4))
+      defaultLeft.doubleFlatTap(i => Some(Right(i.length))) mustBe Some(Left(4))
+      defaultLeft.doubleFlatTap(_ => None) mustBe Some(Left(4))
     }
   }
 

--- a/modules/kernel/src/main/scala/tofu/syntax/feither.scala
+++ b/modules/kernel/src/main/scala/tofu/syntax/feither.scala
@@ -71,6 +71,12 @@ object feither {
     def mapIn[B](f: R => B)(implicit F: Functor[F]): F[Either[L, B]] =
       e.map(_.map(f))
 
+    def asIn[B](b: B)(implicit F: Functor[F]): F[Either[L, B]] =
+      mapIn(_ => b)
+
+    def asF[B](b: F[B])(implicit F: Monad[F]): F[Either[L, B]] =
+      mapF(_ => b)
+
     def leftMapF[L1](f: L => F[L1])(implicit F: Monad[F]): F[Either[L1, R]] = {
       e.flatMap {
         case Left(left)       => f(left).map(_.asLeft)
@@ -103,6 +109,9 @@ object feither {
     def doubleFlatMap[L1 >: L, R1](f: R => F[Either[L1, R1]])(implicit F: Monad[F]): F[Either[L1, R1]] = {
       e.flatMap(_.wideLeft[L1].flatTraverse(f))
     }
+
+    def doubleFlatTap[L1 >: L, R1](f: R => F[Either[L1, R1]])(implicit F: Monad[F]): F[Either[L1, R]] =
+      e.doubleFlatMap(r => f(r).asIn(r))
 
     def foldIn[C](lMap: L => C, rMap: R => C)(implicit F: Functor[F]): F[C] = {
       e.map(_.fold(lMap, rMap))


### PR DESCRIPTION
Hi, here is a small suggestion to add a new syntax for feather, the main goal was to add `doubleFlatTap` because I have often felt need in it. In the process, I added `asIn` and `asF` because they were needed for `doubleFlatTap`