### PR TITLE
Update cats-tagless to 0.16.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
 
     val catsMtl = "1.4.0"
 
-    val catsTagless = "0.15.0"
+    val catsTagless = "0.16.0"
 
     val enumeratum = "1.7.3"
 


### PR DESCRIPTION
This PR bumps cats-tagless dep up.

It got never merged in terms of https://github.com/tofu-tf/tofu/pull/1264, https://github.com/tofu-tf/tofu/pull/1233, and https://github.com/tofu-tf/tofu/pull/1266