### PR TITLE
fix: non-dummy writeMarker in Logging RepresentableK instance in Scala 3

### DIFF
--- a/modules/logging/structured/src/main/scala-3/tofu/logging/LoggingRepresentableKInstances.scala
+++ b/modules/logging/structured/src/main/scala-3/tofu/logging/LoggingRepresentableKInstances.scala
@@ -3,6 +3,7 @@ package tofu.logging
 import cats.~>
 import tofu.higherKind.{RepresentableK, RepK}
 import tofu.logging.Logging.Level
+import org.slf4j.Marker
 
 trait LoggingRepresentableKInstances {
 
@@ -11,6 +12,9 @@ trait LoggingRepresentableKInstances {
     def tabulate[F[_]](hom: RepK[Logging, _] ~> F): Logging[F] = new Logging[F] {
       def write(level: Level, message: String, values: LoggedValue*): F[Unit] =
         hom(RepK[Logging](_.write(level, message, values: _*)))
+
+      override def writeMarker(level: Level, message: String, marker: Marker, values: LoggedValue*): F[Unit] =
+        hom(RepK[Logging](_.writeMarker(level, message, marker, values: _*)))
     }
   }
 }


### PR DESCRIPTION
In tofu-logging for Scala 3 a `RepresentableK` instance for `Logging` is not derived but is defined manually. 

That instance does not override `writeMarker` method, but the default `writeMarker` implementation ignores markers.

It can result in marker-erasing implementation for `Logs` if they were constructed using `Mid.attach`