### PR TITLE
Update broken links in documentation (logging)

### DIFF
--- a/docs/tofu.logging.recipes.auto.md
+++ b/docs/tofu.logging.recipes.auto.md
@@ -58,5 +58,5 @@ def foo(bar: Bar): F[Baz] = debug"Entering foo with $bar" *> impl <* debug"Exiti
 ```
 
 ## Example
-Check out the example [here](https://github.com/tofu-tf/tofu/tree/examples/src/main/scala/tofu.example.logging.auto).
+Check out the example [here](https://github.com/tofu-tf/tofu/tree/master/examples/ce2/src/main/scala-2/tofu/example/logging/auto).
 

--- a/docs/tofu.logging.recipes.context.md
+++ b/docs/tofu.logging.recipes.context.md
@@ -112,6 +112,5 @@ and the result is
 ```
 
 ## Example
-Check out the example [here](https://github.com/tofu-tf/tofu/tree/examples/src/main/scala/tofu.example.logging.service).
+Check out the example [here](https://github.com/tofu-tf/tofu/tree/master/examples/ce2/src/main/scala-2/tofu/example/logging/service).
 
-.

--- a/docs/tofu.logging.recipes.md
+++ b/docs/tofu.logging.recipes.md
@@ -14,7 +14,7 @@ For any of the recipes you are going to need three things:
 - import syntax: `import tofu.syntax.logging._`
 - provide correct logback configuration (except when you are using `tofu.logging` with your own implementation) — you
   can find the description [here](./tofu.logging.layouts.md) and the
-  example [here](https://github.com/tofu-tf/tofu/tree/examples/src/main/resources/logback.groovy).
+  example [here](https://github.com/tofu-tf/tofu/blob/master/examples/ce2/src/main/resources/logback.groovy).
 
 Recipes are:
 

--- a/docs/tofu.logging.recipes.simple.md
+++ b/docs/tofu.logging.recipes.simple.md
@@ -50,7 +50,7 @@ def run: IO[ExitCode] = {
 ```
 
 ## Example
-Check out the example [here](https://github.com/tofu-tf/tofu/tree/examples/src/main/scala/tofu.example.logging.simple).
+Check out the example [here](https://github.com/tofu-tf/tofu/blob/master/examples/ce2/src/main/scala-2/tofu/example/logging/simple).
 
 
 


### PR DESCRIPTION
It seems that at some point in the past, the `examples` branch was deleted, and therefore some links from the documentation became irrelevant. I have updated the links for three examples in logging (simple, service, auto), but there is one broken link left (logback groovy format):
https://github.com/tofu-tf/tofu/blob/e563e36a5c22c4fd36f2d424d152ba6a13d8555d/docs/tofu.logging.recipes.md?plain=1#L15-L17
If you know the new location of this file, please let me know, I will be happy to add the appropriate changes to this pull request.

I have updated the links so that they point to the `master` branch, or more specifically to the `examples/ce2/src/main/scala-2/tofu/example/logging`.

