### PR TITLE
ZLogAnnotation.makePlain annotation

### DIFF
--- a/modules/interop/zio2/logging/src/main/scala/tofu/logging/zlogs/ZLogAnnotation.scala
+++ b/modules/interop/zio2/logging/src/main/scala/tofu/logging/zlogs/ZLogAnnotation.scala
@@ -1,6 +1,6 @@
 package tofu.logging.zlogs
 
-import tofu.logging.{LogAnnotation, Loggable}
+import tofu.logging.{LogAnnotation, Loggable, LoggedValue}
 import zio.{Scope, Trace, URIO, ZIO, ZIOAspect}
 
 /** The [[LogAnnotation]] extension allows you add structured log annotations into the default log context. The stored
@@ -43,6 +43,11 @@ object ZLogAnnotation {
 
   def make[A](name: String)(implicit L: Loggable[A]): ZLogAnnotation[A] =
     new ZLogAnnotation[A](name, L)
+
+  def makePlain[A](name: String)(implicit L: Loggable[A]): ZLogAnnotation[A] =
+    new ZLogAnnotation[A](name, L) {
+      override def ->(value: Value): LoggedValue = unnamed(value)
+    }
 
   // Don't use these keys
   private val LoggerNameKey              = "_zLoggerName"


### PR DESCRIPTION
This PR adds `ZLogAnnotation.makePlain` overload.

Use case:

i.e. given the [example](https://zio.dev/ecosystem/community/tofu-zio2-logging/), the log is printed in the following shape:

```js
{
  "level": "INFO",
  "logger_name": "my.package.Main",
  "message": "Hello, ZIO logging!",
  "user": {
    "id": 100,
    "login": "use*****",
    "godMode": false
  }
}
```

In some cases we want to lift the underlying values up, outside of the "user" field, to achieve:

```js
{
  "level": "INFO",
  "logger_name": "my.package.Main",
  "message": "Hello, ZIO logging!",
  "id": 100,
  "login": "use*****",
  "godMode": false
}
```

[The reason this PR works](https://github.com/tofu-tf/tofu/blob/master/modules/interop/zio2/logging/src/main/scala/tofu/logging/zlogs/TofuZLogger.scala#L46)


upd: @dos65 asked for some tests; I'll try to find some time to implement those.