### PR TITLE
fix: ci docs publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     name: Update docs
     needs: [build]
     if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes https://github.com/tofu-tf/tofu/actions/runs/16296288588
```
[Invalid workflow file: .github/workflows/ci.yml#L66](https://github.com/tofu-tf/tofu/actions/runs/16296288588/workflow)
The workflow is not valid. .github/workflows/ci.yml (Line: 66, Col: 5): Required property is missing: runs-on
```