### PR TITLE
Use early-semver for publish

### DIFF
--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -6,7 +6,7 @@ ThisBuild / crossScalaVersions := Vector(
   Dependencies.Version.scala3
 )
 
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme := Some("early-semver")
 
 ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 


### PR DESCRIPTION
See https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html