### PR TITLE
Fix TethysBuilder producing `{}` for Foldable types

### DIFF
--- a/modules/logging/derivation/src/test/scala/tofu/logging/derivation/DerivedLoggableSuite.scala
+++ b/modules/logging/derivation/src/test/scala/tofu/logging/derivation/DerivedLoggableSuite.scala
@@ -101,6 +101,10 @@ class DerivedLoggableSuite extends AnyFlatSpec with Matchers {
       "MaskedCustom{sensitiveField=*,firstName=Some(J***),age=**}"
   }
 
+  "top-level list of case classes" should "produce json array" in {
+    json(List(foo, foo)) shouldBe """[{"lol":"zaz","kek":1},{"lol":"zaz","kek":1}]"""
+  }
+
   "MaskedContra logging" should "mask fields" in {
     json(
       MaskedContra(UUID.randomUUID(), LocalDate.of(2023, 12, 1))

--- a/modules/logging/structured/src/main/scala/tofu/logging/Loggable.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/Loggable.scala
@@ -63,6 +63,10 @@ object Loggable extends LoggableInstances with DataComp[Loggable] {
     /** put single logging field value */
     def putValue[I, V, R, S](a: A, v: V)(implicit r: LogRenderer[I, V, R, S]): S
 
+    /** put value wrapped in its natural container: dict for types with fields, raw value for [[SubLoggable]] */
+    def putWrappedValue[I, V, R, S](a: A, v: V)(implicit r: LogRenderer[I, V, R, S]): S =
+      r.dict(v)(i => fields(a, i))
+
     /** put single logging field value if it's convertible to string, hide it otherwise */
     def putMaskedValue[I, V, R, S](@unused a: A, v: V)(@unused f: String => String)(implicit
         r: LogRenderer[I, V, R, S]
@@ -193,7 +197,8 @@ trait ToStringLoggable[A] extends Loggable[A] {
 
 /** specialized loggable containing no fields, only suitable to be logged as part of something */
 trait SubLoggable[A] extends Loggable[A] {
-  def fields[I, V, R, M](a: A, input: I)(implicit receiver: LogRenderer[I, V, R, M]): R = input.noop
+  def fields[I, V, R, M](a: A, input: I)(implicit receiver: LogRenderer[I, V, R, M]): R        = input.noop
+  override def putWrappedValue[I, V, R, S](a: A, v: V)(implicit r: LogRenderer[I, V, R, S]): S = putValue(a, v)
 }
 
 /** specialized loggable that will not be rendered in the message */

--- a/modules/logging/structured/src/main/scala/tofu/logging/TethysBuilder.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/TethysBuilder.scala
@@ -98,18 +98,25 @@ class TethysBuilder(prefix: String = "", postfix: String = "") extends LogBuilde
 
   def monoid: Monoid[Unit] = implicitly
 
-  def make(f: TokenWriter => Unit): String = {
+  private def renderRaw(f: TokenWriter => Unit): String = {
     val sw     = new StringWriter()
     sw.append(prefix)
     val writer = tethys.jackson.jacksonTokenWriterProducer.forWriter(sw)
-    writer.writeObjectStart()
-    predefined(writer)
     f(writer)
-    writer.writeObjectEnd()
     writer.flush()
     sw.append(postfix)
     sw.toString
   }
+
+  def make(f: TokenWriter => Unit): String = renderRaw { writer =>
+    writer.writeObjectStart()
+    predefined(writer)
+    f(writer)
+    writer.writeObjectEnd()
+  }
+
+  override def apply[A](a: A)(implicit L: Loggable[A]): String =
+    renderRaw(writer => checkWritten(L.putWrappedValue(a, writer)(receiver), writer))
 }
 
 class TethysBuilderWithCustomFields(customFields: List[(String, RawJson)], prefix: String = "", postfix: String = "")
@@ -121,6 +128,9 @@ class TethysBuilderWithCustomFields(customFields: List[(String, RawJson)], prefi
       tokenWriter.writeRawJson(json.json)
     }
   }
+
+  override def apply[A](a: A)(implicit L: Loggable[A]): String =
+    make(d => L.fields(a, d)(receiver))
 }
 
 object TethysBuilder extends TethysBuilder("", "") {

--- a/modules/logging/structured/src/test/scala/tofu/logging/LoggableSuite.scala
+++ b/modules/logging/structured/src/test/scala/tofu/logging/LoggableSuite.scala
@@ -70,6 +70,18 @@ class LoggableSuite extends AnyFlatSpec with Matchers {
   "local date" should "have loggable instance" in {
     LocalDate.ofYearDay(1999, 256).logShow shouldBe "1999-09-13"
   }
+
+  "foldable logging" should "produce json array for list of primitives" in {
+    json(List(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "produce empty json array for empty list" in {
+    json(List.empty[Int]) shouldBe "[]"
+  }
+
+  it should "produce json array for vector of strings" in {
+    json(Vector("a", "b")) shouldBe """["a","b"]"""
+  }
 }
 
 object LoggableSuite {


### PR DESCRIPTION
Resolves #1358.

`TethysBuilder(List(X("value")))` returned `{}` instead of `[{"field":"value"}]` because `LogBuilder.apply` always wrapped output in a JSON object via `make`, but `SubLoggable.fields`, used by `Foldable` instances, is a noop.

This PR adds `putWrappedValue` to `Loggable.Base`, overridden in `SubLoggable`. `TethysBuilder.apply` now uses `putWrappedValue`.

```scala
TethysBuilder(List(1, 2, 3))  // was: {}  now: [1,2,3]
TethysBuilder(Foo("a", Some(1)))  // unchanged: {"str":"a","num":1}
```