### PR TITLE
Add `TethysBuilder.renderValue` without forced object wrapping

### DIFF
--- a/modules/logging/derivation/src/test/scala/tofu/logging/derivation/DerivedLoggableSuite.scala
+++ b/modules/logging/derivation/src/test/scala/tofu/logging/derivation/DerivedLoggableSuite.scala
@@ -101,6 +101,10 @@ class DerivedLoggableSuite extends AnyFlatSpec with Matchers {
       "MaskedCustom{sensitiveField=*,firstName=Some(J***),age=**}"
   }
 
+  "TethysBuilder.renderValue" should "produce json array for list of case classes" in {
+    TethysBuilder.renderValue(List(foo, foo)) shouldBe """[{"lol":"zaz","kek":1},{"lol":"zaz","kek":1}]"""
+  }
+
   "MaskedContra logging" should "mask fields" in {
     json(
       MaskedContra(UUID.randomUUID(), LocalDate.of(2023, 12, 1))

--- a/modules/logging/structured/src/main/scala/tofu/logging/LogRenderer.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/LogRenderer.scala
@@ -125,7 +125,11 @@ trait LogBuilder[U] {
   def build[A](as: A*)(implicit L: Loggable[A]): U =
     make { d => as.foldLeft(d.noop)((acc, a) => acc |+| L.fields(a, d)) }
 
-  /** accept loggable value and produce the result */
+  /** accept loggable value and produce the result
+    *
+    * @note
+    *   non-dict types ([[SubLoggable]]) have no fields, so this will produce an empty result for them
+    */
   def apply[A](a: A)(implicit L: Loggable[A]): U =
     make(d => L.fields(a, d))
 }

--- a/modules/logging/structured/src/main/scala/tofu/logging/TethysBuilder.scala
+++ b/modules/logging/structured/src/main/scala/tofu/logging/TethysBuilder.scala
@@ -98,18 +98,28 @@ class TethysBuilder(prefix: String = "", postfix: String = "") extends LogBuilde
 
   def monoid: Monoid[Unit] = implicitly
 
-  def make(f: TokenWriter => Unit): String = {
+  private def renderRaw(f: TokenWriter => Unit): String = {
     val sw     = new StringWriter()
     sw.append(prefix)
     val writer = tethys.jackson.jacksonTokenWriterProducer.forWriter(sw)
-    writer.writeObjectStart()
-    predefined(writer)
     f(writer)
-    writer.writeObjectEnd()
     writer.flush()
     sw.append(postfix)
     sw.toString
   }
+
+  def make(f: TokenWriter => Unit): String = renderRaw { writer =>
+    writer.writeObjectStart()
+    predefined(writer)
+    f(writer)
+    writer.writeObjectEnd()
+  }
+
+  /** render a loggable value directly via [[Loggable.putValue]], without wrapping in a JSON object unlike [[apply]]
+    * this correctly handles non-dict types instead of producing empty objects
+    */
+  def renderValue[A](a: A)(implicit L: Loggable[A]): String =
+    renderRaw(writer => checkWritten(L.putValue(a, writer)(receiver), writer))
 }
 
 class TethysBuilderWithCustomFields(customFields: List[(String, RawJson)], prefix: String = "", postfix: String = "")

--- a/modules/logging/structured/src/test/scala/tofu/logging/LoggableSuite.scala
+++ b/modules/logging/structured/src/test/scala/tofu/logging/LoggableSuite.scala
@@ -70,6 +70,26 @@ class LoggableSuite extends AnyFlatSpec with Matchers {
   "local date" should "have loggable instance" in {
     LocalDate.ofYearDay(1999, 256).logShow shouldBe "1999-09-13"
   }
+
+  "TethysBuilder.renderValue" should "produce json array for list of primitives" in {
+    TethysBuilder.renderValue(List(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "produce empty json array for empty list" in {
+    TethysBuilder.renderValue(List.empty[Int]) shouldBe "[]"
+  }
+
+  it should "produce json array for vector of strings" in {
+    TethysBuilder.renderValue(Vector("a", "b")) shouldBe """["a","b"]"""
+  }
+
+  it should "produce number for int" in {
+    TethysBuilder.renderValue(1) shouldBe "1"
+  }
+
+  it should "produce string for string" in {
+    TethysBuilder.renderValue("lol") shouldBe """"lol""""
+  }
 }
 
 object LoggableSuite {


### PR DESCRIPTION
Resolves #1358.

`TethysBuilder(List(X("value")))` returns `{}` instead of `[{"field":"value"}]` because `LogBuilder.apply` always wraps output in a JSON object via `make`, but `SubLoggable.fields`, used for non-dict types like lists or ints, is a noop.
This PR adds `TethysBuilder.renderValue` that renders any loggable value in its natural JSON form.

```scala
TethysBuilder.renderValue(List(1, 2, 3))  // [1,2,3]
TethysBuilder(List(1, 2, 3))              // {} (unchanged)