### PR TITLE
Migrate tofu-doobie-ce3 to doobie 1.0.0-RC13 (org.typelevel)

### DIFF
--- a/examples/ce3/src/main/scala-2/tofu/example/doobie/TofuDoobieExample.scala
+++ b/examples/ce3/src/main/scala-2/tofu/example/doobie/TofuDoobieExample.scala
@@ -6,9 +6,9 @@ import cats.effect.{Async, IO, IOApp}
 import cats.tagless.syntax.functorK._
 import cats.{Apply, Monad}
 import derevo.derive
-import doobie._
-import doobie.implicits._
-import doobie.util.log.LogHandler
+import org.typelevel.doobie._
+import org.typelevel.doobie.implicits._
+import org.typelevel.doobie.util.log.LogHandler
 import tofu.doobie.LiftConnectionIO
 import tofu.doobie.transactor.Txr
 import tofu.higherKind.RepresentableK

--- a/modules/doobie/core-ce3/src/main/scala/tofu/doobie/ConnectionCIO.scala
+++ b/modules/doobie/core-ce3/src/main/scala/tofu/doobie/ConnectionCIO.scala
@@ -2,7 +2,7 @@ package tofu.doobie
 
 import cats.data.Kleisli
 import cats.~>
-import doobie.ConnectionIO
+import org.typelevel.doobie.ConnectionIO
 import tofu.kernel.types.AnyK
 
 object ConnectionCIO extends ConnectionCIOCrossVersion {

--- a/modules/doobie/core-ce3/src/main/scala/tofu/doobie/package.scala
+++ b/modules/doobie/core-ce3/src/main/scala/tofu/doobie/package.scala
@@ -1,6 +1,6 @@
 package tofu
 
-import _root_.doobie.ConnectionIO
+import _root_.org.typelevel.doobie.ConnectionIO
 import cats.data.Kleisli
 import tofu.lift.Lift
 

--- a/modules/doobie/core-ce3/src/main/scala/tofu/doobie/transactor/Txr.scala
+++ b/modules/doobie/core-ce3/src/main/scala/tofu/doobie/transactor/Txr.scala
@@ -4,13 +4,13 @@ package transactor
 import cats.data.Kleisli
 import cats.effect.{MonadCancelThrow, Resource}
 import cats.~>
-import doobie.{ConnectionIO, Transactor}
 import fs2.Stream
+import org.typelevel.doobie.{ConnectionIO, Transactor}
 import tofu.syntax.funk._
 import tofu.syntax.monadic._
 
-/** A simple facade for [[doobie.Transactor]] that holds an inner database effect type `DB[_]` and provides natural
-  * transformations from this effect to the target effect `F[_]`.
+/** A simple facade for [[org.typelevel.doobie.Transactor]] that holds an inner database effect type `DB[_]` and
+  * provides natural transformations from this effect to the target effect `F[_]`.
   *
   * The motivation for using this facade instead of `Transactor` is to:
   *

--- a/modules/doobie/core-ce3/src/test/scala/tofu/doobie/DoobieInstancesSuite.scala
+++ b/modules/doobie/core-ce3/src/test/scala/tofu/doobie/DoobieInstancesSuite.scala
@@ -1,6 +1,6 @@
 package tofu.doobie
 
-import doobie.ConnectionIO
+import org.typelevel.doobie.ConnectionIO
 import tofu.lift.Lift
 
 object DoobieInstancesSuite {

--- a/modules/doobie/logging-ce3/src/main/scala/tofu/doobie/log/LoggableSqlInterpolator.scala
+++ b/modules/doobie/logging-ce3/src/main/scala/tofu/doobie/log/LoggableSqlInterpolator.scala
@@ -1,11 +1,11 @@
 package tofu.doobie.log
-import doobie.syntax.SqlInterpolator
+import org.typelevel.doobie.syntax.SqlInterpolator
 
 import scala.{specialized => sp}
-import doobie.syntax.SqlInterpolator.SingleFragment
-import doobie.util.Put
-import doobie.util.fragment.Fragment
-import doobie.util.pos.Pos
+import org.typelevel.doobie.syntax.SqlInterpolator.SingleFragment
+import org.typelevel.doobie.util.Put
+import org.typelevel.doobie.util.fragment.Fragment
+import org.typelevel.doobie.util.pos.Pos
 import tofu.doobie.log.LoggableSqlInterpolator.LoggableSingleFragment
 import tofu.logging.{LogRenderer, Loggable, LoggedValue}
 

--- a/modules/doobie/logging-ce3/src/main/scala/tofu/doobie/log/instances.scala
+++ b/modules/doobie/logging-ce3/src/main/scala/tofu/doobie/log/instances.scala
@@ -1,7 +1,7 @@
 package tofu.doobie.log
 
 import cats.syntax.monoid._
-import doobie.util.log._
+import org.typelevel.doobie.util.log._
 import tofu.logging.{DictLoggable, LogRenderer, Loggable, LoggedValue}
 import tofu.syntax.logRenderer._
 

--- a/modules/doobie/logging-ce3/src/main/scala/tofu/syntax/doobie/log/handler.scala
+++ b/modules/doobie/logging-ce3/src/main/scala/tofu/syntax/doobie/log/handler.scala
@@ -1,6 +1,6 @@
 package tofu.syntax.doobie.log
 
-import doobie.util.log._
+import org.typelevel.doobie.util.log._
 import tofu.doobie.log.instances._
 import tofu.kernel.types.AnyK
 import tofu.logging.Logging

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
 
     val doobie = "0.13.4"
 
-    val doobieCE3 = "1.0.0-RC12"
+    val doobieCE3 = "1.0.0-RC13"
 
     // Compile time only
     val macroParadise = "2.1.1"
@@ -131,8 +131,8 @@ object Dependencies {
   val refined           = "eu.timepit"                   %% "refined"                  % Version.refined
   val doobieCore        = "org.tpolecat"                 %% "doobie-core"              % Version.doobie
   val doobieH2          = "org.tpolecat"                 %% "doobie-h2"                % Version.doobie
-  val doobieCoreCE3     = "org.tpolecat"                 %% "doobie-core"              % Version.doobieCE3
-  val doobieH2CE3       = "org.tpolecat"                 %% "doobie-h2"                % Version.doobieCE3
+  val doobieCoreCE3     = "org.typelevel"                %% "doobie-core"              % Version.doobieCE3
+  val doobieH2CE3       = "org.typelevel"                %% "doobie-h2"                % Version.doobieCE3
   val collectionCompat  = "org.scala-lang.modules"       %% "scala-collection-compat"  % Version.collectionCompat
   val log4CatsLegacy    = "org.typelevel"                %% "log4cats-core"            % Version.log4CatsLegacy
   val log4Cats          = "org.typelevel"                %% "log4cats-core"            % Version.log4Cats


### PR DESCRIPTION
Doobie moved the project to the Typelevel organization with two breaking changes:

| | groupId | root package |
|---|---|---|
| ≤ RC12 | `org.tpolecat` | `doobie.*` |
| RC13 | `org.typelevel` | `org.typelevel.doobie.*` |

This PR rewrites `doobie.` → `org.typelevel.doobie.`  across the CE3 modules: `tofu-doobie-ce3`, `tofu-doobie-logging-ce3` and the CE3 example.
CE2 modules are untouched.

There is also existing #1550 PR, which changes the `groupId` on all doobie-related modules, including the CE2 pair. This is wrong approach, since `doobie % 0.13.4` (the last doobie version with Cats Effect 2) was never published under `org.typelevel`.