### PR TITLE
Make `fmt` and `checkfmt` aliases cover all Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -678,7 +678,7 @@ lazy val noPublishSettings =
 lazy val exampleSettings =
   noPublishSettings ++ Set(evictionErrorLevel := Level.Info)
 
-addCommandAlias("fmt", "all tofu/scalafmtSbt tofu/scalafmtAll")
-addCommandAlias("checkfmt", "all tofu/scalafmtSbtCheck tofu/scalafmtCheckAll")
+addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
+addCommandAlias("checkfmt", "all scalafmtSbtCheck scalafmtCheckAll")
 
 addCommandAlias("preparePR", "scalafmtAll ;scalafmtSbt ;reload; clean; Test / compile")


### PR DESCRIPTION
`fmt` and `checkfmt` aliases now are scoped to the `tofu/` aggregate, which under `sbt-projectmatrix` resolves only to Scala 2.13. These are probably leftovers from refactors.
At the same time, CI runs `sbt scalafmtCheckAll scalafmtSbtCheck` on the root project.

This PR drops the `tofu/` scoping, so both aliases run on the aggregating root.